### PR TITLE
Normalise validation failure order

### DIFF
--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -24,13 +24,13 @@ use function array_map;
 use function array_reduce;
 use function count;
 use function Functional\map;
+use function Functional\sort;
 use function implode;
 use function is_int;
 use function is_readable;
 use function preg_match_all;
 use function sprintf;
 use function str_replace;
-use function usort;
 use const PHP_EOL;
 use const PREG_SET_ORDER;
 
@@ -63,35 +63,6 @@ final class SchemaTest extends TestCase
         } catch (ValidationFailed $e) {
             $this->assertEquals($expected, $this->normaliseFailuresOrder($e->getFailures()));
         }
-    }
-
-    /**
-     * @param array<Failure> $failures
-     *
-     * @return array<Failure>
-     */
-    private function normaliseFailuresOrder(array $failures) : array
-    {
-        usort(
-            $failures,
-            function (Failure $a, Failure $b) {
-                if ($a->getLine() !== $b->getLine()) {
-                    return $a->getLine() <=> $b->getLine();
-                }
-
-                if (!$a->getNode() instanceof DOMNode || !$b->getNode() instanceof DOMNode) {
-                    return $a->getNode() instanceof DOMNode <=> $b->getNode() instanceof DOMNode;
-                }
-
-                if ($a->getNode()->getNodePath() !== $b->getNode()->getNodePath()) {
-                    return $a->getNode()->getNodePath() <=> $b->getNode()->getNodePath();
-                }
-
-                return $a->getMessage() <=> $b->getMessage();
-            }
-        );
-
-        return $failures;
     }
 
     public function fileProvider() : iterable
@@ -206,5 +177,32 @@ final class SchemaTest extends TestCase
         }
 
         return sprintf('%s (%s)', $failure->getMessage(), $failure->getNode()->getNodePath());
+    }
+
+    /**
+     * @param array<Failure> $failures
+     *
+     * @return array<Failure>
+     */
+    private function normaliseFailuresOrder(array $failures) : array
+    {
+        return sort(
+            $failures,
+            function (Failure $a, Failure $b) {
+                if ($a->getLine() !== $b->getLine()) {
+                    return $a->getLine() <=> $b->getLine();
+                }
+
+                if (!$a->getNode() instanceof DOMNode || !$b->getNode() instanceof DOMNode) {
+                    return $a->getNode() instanceof DOMNode <=> $b->getNode() instanceof DOMNode;
+                }
+
+                if ($a->getNode()->getNodePath() !== $b->getNode()->getNodePath()) {
+                    return $a->getNode()->getNodePath() <=> $b->getNode()->getNodePath();
+                }
+
+                return $a->getMessage() <=> $b->getMessage();
+            }
+        );
     }
 }

--- a/tests/cases/count.xml
+++ b/tests/cases/count.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?expected-error message="<count> is ignored." node="/count"?>
 <?expected-error message="@count-type is ignored." node="//@count-type"?>
 <?expected-error message="@count is ignored." node="//@count"?>
-<?expected-error message="<count> is ignored." node="/count"?>
 
 <count count-type="" count="0"/>

--- a/tests/cases/equation-count.xml
+++ b/tests/cases/equation-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<equation-count> is ignored." node="/equation-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <equation-count count="0"/>

--- a/tests/cases/fig-count.xml
+++ b/tests/cases/fig-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<fig-count> is ignored." node="/fig-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <fig-count count="0"/>

--- a/tests/cases/graphic.xml
+++ b/tests/cases/graphic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 <?expected-error message="<graphic> is ignored." node="/graphic"?>
+<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 
-<graphic xlink:href="" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+<graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=""/>

--- a/tests/cases/inline-graphic.xml
+++ b/tests/cases/inline-graphic.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 <?expected-error message="<inline-graphic> is ignored." node="/inline-graphic"?>
+<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 
-<inline-graphic xlink:href="" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+<inline-graphic xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=""/>

--- a/tests/cases/media.xml
+++ b/tests/cases/media.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 <?expected-error message="<media> is ignored." node="/media"?>
+<?expected-error message="@xlink:href is ignored." node="//@xlink:href"?>
 
-<media xlink:href="" xmlns:xlink="http://www.w3.org/1999/xlink"/>
+<media xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href=""/>

--- a/tests/cases/named-content.xml
+++ b/tests/cases/named-content.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@content-type is ignored." node="//@content-type"?>
 <?expected-error message="<named-content> is ignored." node="/named-content"?>
+<?expected-error message="@content-type is ignored." node="//@content-type"?>
 
 <named-content content-type=""/>

--- a/tests/cases/overline-end.xml
+++ b/tests/cases/overline-end.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="IDREF attribute rid references an unknown ID \"rid\"" line="8"?>
-<?expected-error message="@rid is ignored." node="//@rid"?>
 <?expected-error message="<overline-end> is ignored." node="/overline-end"?>
+<?expected-error message="@rid is ignored." node="//@rid"?>
+<?expected-error message="IDREF attribute rid references an unknown ID \"rid\"" line="8"?>
 
 <overline-end rid="rid"/>

--- a/tests/cases/overline-start.xml
+++ b/tests/cases/overline-start.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@id is ignored." node="//@id"?>
 <?expected-error message="<overline-start> is ignored." node="/overline-start"?>
+<?expected-error message="@id is ignored." node="//@id"?>
 
 <overline-start id="id"/>

--- a/tests/cases/page-count.xml
+++ b/tests/cases/page-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<page-count> is ignored." node="/page-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <page-count count="0"/>

--- a/tests/cases/ref-count.xml
+++ b/tests/cases/ref-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<ref-count> is ignored." node="/ref-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <ref-count count="0"/>

--- a/tests/cases/related-article.xml
+++ b/tests/cases/related-article.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@related-article-type is ignored." node="//@related-article-type"?>
 <?expected-error message="<related-article> is ignored." node="/related-article"?>
+<?expected-error message="@related-article-type is ignored." node="//@related-article-type"?>
 
 <related-article related-article-type=""/>

--- a/tests/cases/size.xml
+++ b/tests/cases/size.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@units is ignored." node="//@units"?>
 <?expected-error message="<size> is ignored." node="/size"?>
+<?expected-error message="@units is ignored." node="//@units"?>
 
 <size units=""/>

--- a/tests/cases/table-count.xml
+++ b/tests/cases/table-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<table-count> is ignored." node="/table-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <table-count count="0"/>

--- a/tests/cases/target.xml
+++ b/tests/cases/target.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@id is ignored." node="//@id"?>
 <?expected-error message="<target> is ignored." node="/target"?>
+<?expected-error message="@id is ignored." node="//@id"?>
 
 <target id="id"/>

--- a/tests/cases/underline-end.xml
+++ b/tests/cases/underline-end.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="IDREF attribute rid references an unknown ID \"rid\"" line="8"?>
-<?expected-error message="@rid is ignored." node="//@rid"?>
 <?expected-error message="<underline-end> is ignored." node="/underline-end"?>
+<?expected-error message="@rid is ignored." node="//@rid"?>
+<?expected-error message="IDREF attribute rid references an unknown ID \"rid\"" line="8"?>
 
 <underline-end rid="rid"/>

--- a/tests/cases/underline-start.xml
+++ b/tests/cases/underline-start.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@id is ignored." node="//@id"?>
 <?expected-error message="<underline-start> is ignored." node="/underline-start"?>
+<?expected-error message="@id is ignored." node="//@id"?>
 
 <underline-start id="id"/>

--- a/tests/cases/word-count.xml
+++ b/tests/cases/word-count.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="../jats.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../../src/support.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?expected-error message="@count is ignored." node="//@count"?>
 <?expected-error message="<word-count> is ignored." node="/word-count"?>
+<?expected-error message="@count is ignored." node="//@count"?>
 
 <word-count count="0"/>


### PR DESCRIPTION
The order of the errors isn't actually important; the most useful way to write `expected-error` is to match the order of the nodes.